### PR TITLE
Minor getVars() fixes:  cyclic data display and non-numerically-indexed DTO properties

### DIFF
--- a/src/Structure/DTO.php
+++ b/src/Structure/DTO.php
@@ -130,6 +130,8 @@ abstract class DTO {
                 if (!isset($previousDTOs[spl_object_hash($this->{$property->name})])) {
                     // Get it's vars
                     $var = $this->{$property->name}->getVarsWithoutCircularReferences($showNulls, $previousDTOs);
+                } else {
+                    $var = null;
                 }
             // If it's an array of DTOs
             } else if (is_array($this->{$property->name})

--- a/src/Structure/DTO.php
+++ b/src/Structure/DTO.php
@@ -136,7 +136,7 @@ abstract class DTO {
             // If it's an array of DTOs
             } else if (is_array($this->{$property->name})
                     && count($this->{$property->name}) > 0
-                    && $this->{$property->name}[0] instanceof DTO) {
+                    && ($this->{$property->name}[0] ?? null) instanceof DTO) {
                 $var = array();
                 // Get the vars for each
                 foreach ($this->{$property->name} as $i => $v) {


### PR DESCRIPTION
Fixed bugs in getVars() wherein:
- it will display the value of the previous property if the property being displayed is cyclic
- it will trigger an undefined offset error when a property is an array with non-numeric keys
