### PR TITLE
Same references not on the same tree branch should not be circular

### DIFF
--- a/src/Structure/DTO.php
+++ b/src/Structure/DTO.php
@@ -156,6 +156,7 @@ abstract class DTO {
                 $vars[$this->camelToUnderscore($property->name)] = $var;
             }
         }
+        unset($previousDTOs[spl_object_hash($this)]);
         return $vars;
     }
 


### PR DESCRIPTION
Fixes bug wherein some attributes are not being saved because they are being considered circular when they are not.